### PR TITLE
Fix: Remove possibility to specify version via COMPOSER_NORMALIZE_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.6.0...master`][0.6.0...master].
 
+### Changed
+
+* Removed possibility to configure version of `ergebnis/composer-normalize` via `COMPOSER_NORMALIZE_VERSION` environment variable ([#63]), by [@localheinz]
+
 ## [`0.6.0`][0.6.0]
 
 For a full diff see [`0.5.2...0.6.0`][0.5.2...0.6.0].
@@ -190,6 +194,7 @@ For a full diff see [`afa2393...0.1.0`][afa2393...0.1.0].
 [#50]: https://github.com/ergebnis/composer-normalize-action/pull/50
 [#57]: https://github.com/ergebnis/composer-normalize-action/pull/57
 [#59]: https://github.com/ergebnis/composer-normalize-action/pull/59
+[#63]: https://github.com/ergebnis/composer-normalize-action/pull/63
 
 [@localheinz]: https://github.com/localheinz
 [@ergebnis]: https://github.com/localheinz

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ LABEL "maintainer"="Andreas Möller <am@localheinz.com>"
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
-ENV COMPOSER_NORMALIZE_VERSION_DEFAULT=2.1.2
 
-RUN composer global require ergebnis/composer-normalize:$COMPOSER_NORMALIZE_VERSION_DEFAULT --no-interaction --no-progress --no-suggest
+RUN composer global require ergebnis/composer-normalize:2.1.2 --no-interaction --no-progress --no-suggest
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -116,39 +116,6 @@ Instead of using the latest pre-built Docker image, you can also specify a Docke
 +        uses: docker://ergebnis/composer-normalize-action:0.4.2
 ```
 
-### Environment Variables
-
-If you wish to specify the version of [`ergebnis/composer-normalize`](https://github.com/ergebnis/composer-normalize)  that should be used by the action, you can use the `COMPOSER_NORMALIZE_VERSION` environment variable:
-
-```diff
- name: Continuous Integration
-
- on: push
-
- jobs:
-   composer-normalize:
-     name: composer-normalize
-
-     runs-on: ubuntu-latest
-
-     steps:
-       - name: "Checkout"
-         uses: actions/checkout@master
-
-       - name: composer-normalize-action
-         uses: docker://ergebnis/composer-normalize-action:latest
-+        env:
-+          COMPOSER_NORMALIZE_VERSION: '^2.1.2'
-```
-
-This value will be passed to [`entrypoint.sh`](entrypoint.sh) where it will be used for running
-
-```
-$ composer global require ergebnis/composer-normalize:$COMPOSER_NORMALIZE_VERSION
-```
-
-It can be any value that is understood by [`composer`](https://getcomposer.org/doc/articles/versions.md).
-
 ## Changelog
 
 Please have a look at [`CHANGELOG.md`](CHANGELOG.md).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/bin/sh -l
 
-if [ -n "$COMPOSER_NORMALIZE_VERSION" ] && [ "$COMPOSER_NORMALIZE_VERSION" != "$COMPOSER_NORMALIZE_VERSION_DEFAULT" ]; then
-  composer global require ergebnis/composer-normalize:"$COMPOSER_NORMALIZE_VERSION" --no-interaction --no-progress --no-suggest;
-fi
-
 if [ "$HOME" != '/root' ]; then
   cp -r /root/.composer "$HOME"/.composer;
 fi


### PR DESCRIPTION
This PR

* [x] removes the possibility to specify the version of `ergebnis/composer-normalize` via `COMPOSER_NORMALIZE_VERSION` environment variable
