### PR TITLE
Fix: Do not bother specifying DOCKER_USERNAME as secret

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -17,6 +17,7 @@ jobs:
 
     env:
       DOCKER_IMAGE: "ergebnis/composer-normalize-action"
+      DOCKER_USERNAME: "ergebnis"
 
     steps:
       - name: "Checkout"
@@ -27,7 +28,7 @@ jobs:
 
       - name: "Docker Login"
         if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"
-        run: "echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ secrets.DOCKER_USERNAME }}"
+        run: "echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ env.DOCKER_USERNAME }}"
 
       - name: "Push Docker image (latest)"
         if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"


### PR DESCRIPTION
This PR

* [x] provides `DOCKER_USERNAME` as environment variable instead of as a secret